### PR TITLE
Fix sign error in Platt scaling sigmoid

### DIFF
--- a/src/ml/PlattScaling.hpp
+++ b/src/ml/PlattScaling.hpp
@@ -6,13 +6,17 @@
 
 namespace sim::ml {
 
-// Fit logistic: P(y=1|s) = 1 / (1 + exp(A s + B)) on decision scores s with labels y in {+1,-1}
+// Fit logistic: P(y=1|s) = 1 / (1 + exp(-(A s + B))) on decision scores s with labels y in {+1,-1}
 struct PlattScaler {
     float A{0.0f};
     float B{0.0f};
     bool fitted{false};
 
-    static float sigmoid(float t) { return 1.0f / (1.0f + std::exp(t)); }
+    // Standard logistic sigmoid; previous implementation used `exp(t)` which
+    // incorrectly flipped the probability for positive inputs (p(t>0)<0.5).
+    // Using `exp(-t)` yields the conventional monotonically increasing
+    // function in [0,1].
+    static float sigmoid(float t) { return 1.0f / (1.0f + std::exp(-t)); }
 
     void fit(const std::vector<float>& scores, const std::vector<int>& labels, int iters = 200, float lr = 0.01f) {
         if (scores.empty()) { fitted = false; return; }


### PR DESCRIPTION
## Summary
- Correct logistic sigmoid in `PlattScaling` to use `exp(-t)`
- Update documentation and explanation for correct probability mapping

## Testing
- `g++ -std=c++20 -I src -I /usr/include/eigen3 -xc++ - <<'EOF'
#include "ml/PlattScaling.hpp"
#include <iostream>
int main(){ std::cout<<sim::ml::PlattScaler::sigmoid(1.0f)<<"\n"<<sim::ml::PlattScaler::sigmoid(-1.0f)<<"\n"; }
EOF`
- `./a.out`


------
https://chatgpt.com/codex/tasks/task_e_689f36f08b2483259622de783757732e